### PR TITLE
Remove test-bundler task in snapshot-ruby_2_7 on macos

### DIFF
--- a/.github/workflows/snapshot-ruby_2_7.yml
+++ b/.github/workflows/snapshot-ruby_2_7.yml
@@ -178,7 +178,7 @@ jobs:
     needs: make-snapshot
     strategy:
       matrix:
-        test_task: [check, test-bundler, test-bundled-gems]
+        test_task: [check, test-bundled-gems]
         os: [macos-latest]
       fail-fast: false
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
snapshot-ruby_2_7 workflow fails continuously on macos at make test-bundler task.

I investigated and found that the root cause may be the pre-installed gems on the environment.
I think we can eliminate test-bundler on macos, because the test-bundler also run on ubuntu environment.

BTW I have decided to handle the failure of test-bundler on ruby/ruby repo in the different way, uninstalling all gems on macos env before run test tasks.