### PR TITLE
Remove ubuntu-16.04

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -127,12 +127,7 @@ jobs:
     strategy:
       matrix:
         test_task: [check, test-bundler, test-bundled-gems]
-        os: [ubuntu-20.04, ubuntu-18.04, ubuntu-16.04]
-        exclude:
-          - test_task: test-bundler
-            os: ubuntu-16.04
-          - test_task: test-bundled-gems
-            os: ubuntu-16.04
+        os: [ubuntu-20.04, ubuntu-18.04]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/snapshot-master.yml
+++ b/.github/workflows/snapshot-master.yml
@@ -69,12 +69,7 @@ jobs:
     strategy:
       matrix:
         test_task: [check, test-bundler-parallel, test-bundled-gems]
-        os: [ubuntu-20.04, ubuntu-18.04, ubuntu-16.04]
-        exclude:
-          - test_task: test-bundler-parallel
-            os: ubuntu-16.04
-          - test_task: test-bundled-gems
-            os: ubuntu-16.04
+        os: [ubuntu-20.04, ubuntu-18.04]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/snapshot-ruby_2_6.yml
+++ b/.github/workflows/snapshot-ruby_2_6.yml
@@ -72,12 +72,7 @@ jobs:
     strategy:
       matrix:
         test_task: [check, test-bundler, test-bundled-gems]
-        os: [ubuntu-20.04, ubuntu-18.04, ubuntu-16.04]
-        exclude:
-          - test_task: test-bundler
-            os: ubuntu-16.04
-          - test_task: test-bundled-gems
-            os: ubuntu-16.04
+        os: [ubuntu-20.04, ubuntu-18.04]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/snapshot-ruby_2_7.yml
+++ b/.github/workflows/snapshot-ruby_2_7.yml
@@ -72,12 +72,7 @@ jobs:
     strategy:
       matrix:
         test_task: [check, test-bundler, test-bundled-gems]
-        os: [ubuntu-20.04, ubuntu-18.04, ubuntu-16.04]
-        exclude:
-          - test_task: test-bundler
-            os: ubuntu-16.04
-          - test_task: test-bundled-gems
-            os: ubuntu-16.04
+        os: [ubuntu-20.04, ubuntu-18.04]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/snapshot-ruby_3_0.yml
+++ b/.github/workflows/snapshot-ruby_3_0.yml
@@ -72,12 +72,7 @@ jobs:
     strategy:
       matrix:
         test_task: [check, test-bundler, test-bundled-gems]
-        os: [ubuntu-20.04, ubuntu-18.04, ubuntu-16.04]
-        exclude:
-          - test_task: test-bundler
-            os: ubuntu-16.04
-          - test_task: test-bundled-gems
-            os: ubuntu-16.04
+        os: [ubuntu-20.04, ubuntu-18.04]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
https://github.blog/changelog/2021-04-29-github-actions-ubuntu-16-04-lts-virtual-environment-will-be-removed-on-september-20-2021/