### PR TITLE
Use in-tree ruby/spec examples

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -177,14 +177,6 @@ jobs:
           path: pkg
       - name: Extract
         run: tar xf pkg/ruby-*.tar.xz
-      - name: Update spec
-        run: |
-          set -x
-          git clone --depth=1 https://github.com/ruby/ruby ruby
-          cd ruby-*/
-          rm -rf spec/mspec spec/ruby
-          mv -v ../ruby/spec/mspec ../ruby/spec/ruby spec
-        if: matrix.test_task == 'check'
       - name: Install libraries
         run: |
           set -x

--- a/.github/workflows/snapshot-ruby_2_7.yml
+++ b/.github/workflows/snapshot-ruby_2_7.yml
@@ -119,14 +119,6 @@ jobs:
         env:
           RUBY_PATCH_URL: "${{ github.event.inputs.RUBY_PATCH_URL }}"
         if: "${{ github.event.inputs.RUBY_PATCH_URL != '' }}"
-      - name: Update spec
-        run: |
-          set -x
-          git clone --depth=1 https://github.com/ruby/ruby ruby
-          cd snapshot-*/
-          rm -rf spec/mspec spec/ruby
-          mv -v ../ruby/spec/mspec ../ruby/spec/ruby spec
-        if: matrix.test_task == 'check'
       - name: Install libraries
         run: |
           set -x

--- a/.github/workflows/snapshot-ruby_3_0.yml
+++ b/.github/workflows/snapshot-ruby_3_0.yml
@@ -118,14 +118,6 @@ jobs:
         env:
           RUBY_PATCH_URL: "${{ github.event.inputs.RUBY_PATCH_URL }}"
         if: "${{ github.event.inputs.RUBY_PATCH_URL != '' }}"
-      - name: Update spec
-        run: |
-          set -x
-          git clone --depth=1 https://github.com/ruby/ruby ruby
-          cd snapshot-*/
-          rm -rf spec/mspec spec/ruby
-          mv -v ../ruby/spec/mspec ../ruby/spec/ruby spec
-        if: matrix.test_task == 'check'
       - name: Install libraries
         run: |
           set -x

--- a/.github/workflows/snapshot-ruby_3_1.yml
+++ b/.github/workflows/snapshot-ruby_3_1.yml
@@ -118,14 +118,6 @@ jobs:
         env:
           RUBY_PATCH_URL: "${{ github.event.inputs.RUBY_PATCH_URL }}"
         if: "${{ github.event.inputs.RUBY_PATCH_URL != '' }}"
-      - name: Update spec
-        run: |
-          set -x
-          git clone --depth=1 https://github.com/ruby/ruby ruby
-          cd snapshot-*/
-          rm -rf spec/mspec spec/ruby
-          mv -v ../ruby/spec/mspec ../ruby/spec/ruby spec
-        if: matrix.test_task == 'check'
       - name: Install libraries
         run: |
           set -x


### PR DESCRIPTION
We discuss about this. There is no reason why we always use `ruby/spec` HEAD for the stable versions today.