### PR TITLE
Revert "Add workaround for test-bundled-gems"

### DIFF
--- a/.github/workflows/snapshot-master.yml
+++ b/.github/workflows/snapshot-master.yml
@@ -299,15 +299,6 @@ jobs:
         run: cd snapshot-*/ && ./configure --with-openssl-dir=$(brew --prefix openssl@1.1) --with-readline-dir=$(brew --prefix readline) --with-libyaml-dir=$(brew --prefix libyaml)
       - name: make
         run: cd snapshot-*/ && make $JOBS
-      - name: Remove .bundle for workaround
-        # ./tool/test-bundled-gems.rb:10:in `realpath': Not a directory @ rb_check_realpath_internal - ./tool/test-bundled-gems.rb/../../.bundle/bin/rake (Errno::ENOTDIR)
-        # from ./tool/test-bundled-gems.rb:10:in `<main>'
-        run: |
-          cd snapshot-*/
-          if [ ! -e .bundle/bin/rake ]; then
-            rm -rf .bundle
-          fi
-        if: matrix.test_task == 'test-bundled-gems'
       - name: Tests
         run: cd snapshot-*/ && make $JOBS -s ${{ matrix.test_task }}
         env:


### PR DESCRIPTION
This reverts commit 0accf840d7e3fab3bb754d18f17ece3fd48942fd.

Currently the test-bundled-gems runs successfully on snapshot-ruby_3_1 without the workaround. It might not be necessary already.