### PR TITLE
fixup adf43c849c21c3fb2d5b7e109027b41ed2ff4e1a.

### DIFF
--- a/.github/workflows/snapshot-master.yml
+++ b/.github/workflows/snapshot-master.yml
@@ -202,7 +202,7 @@ jobs:
             end
           end
           File.open("/tmp/stat-after-tests.txt", "w") do |io|
-            puts out.sort
+            io.puts out.sort
           end
           EOF
           make runruby


### PR DESCRIPTION
Failed to use IO#puts but Kernel#puts. 