### PR TITLE
Revert "Unify -packages option"

### DIFF
--- a/.github/actions/make-snapshot/action.yml
+++ b/.github/actions/make-snapshot/action.yml
@@ -37,8 +37,10 @@ runs:
         git fetch origin '+refs/notes/log-fix:refs/notes/log-fix'
       shell: bash
     - name: Make snapshot
-      run: >-
-        ruby ruby/tool/make-snapshot -archname=$archname -srcdir=ruby
-        ${{ !inputs.generate-tar-bz2 && '-packages=gzip,xz,zip' }}
-        pkg ${{ inputs.version }}
+      run: |
+        if [ -n "${{ inputs.generate-tar-bz2 }}" ]; then
+          ruby ruby/tool/make-snapshot -archname=$archname -srcdir=ruby pkg ${{ inputs.version }}
+        else
+          ruby ruby/tool/make-snapshot -archname=$archname -srcdir=ruby -packages=gzip,xz,zip pkg ${{ inputs.version }}
+        fi
       shell: bash


### PR DESCRIPTION
This reverts commit 727e34b40ab321f3b6ec350c7ab051f9d1b580a2.

It seems introduce failure on ruby_2_7 branch.
cf. https://github.com/ruby/actions/actions/runs/3299690916