### PR TITLE
Use stable branch instead of master

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -40,11 +40,11 @@ jobs:
         run: cd ruby && make -s check COVERAGE=true
       - name: Aggregate coverage results
         run: cd ruby && make lcov
-      - uses: actions/upload-artifact@master
+      - uses: actions/upload-artifact@v3
         with:
           name: coverage-latest-html
           path: ruby/lcov-out
-      - uses: actions/upload-artifact@master
+      - uses: actions/upload-artifact@v3
         with:
           name: lcov-all.info
           path: ruby/lcov-all.info

--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -27,7 +27,7 @@ jobs:
       - run: ./configure
       - run: make Doxyfile
       - run: doxygen
-      - uses: actions/upload-artifact@master
+      - uses: actions/upload-artifact@v3
         with:
           name: doxygen-latest-html
           path: doc/capi/html

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -64,11 +64,11 @@ jobs:
               echo PACKAGE_EXTS=".tar.gz .tar.xz .zip" >> $GITHUB_ENV
             fi
           fi
-      - uses: actions/upload-artifact@master
+      - uses: actions/upload-artifact@v3
         with:
           name: Packages
           path: pkg
-      - uses: actions/upload-artifact@master
+      - uses: actions/upload-artifact@v3
         with:
           name: Info
           path: pkg/info
@@ -171,7 +171,7 @@ jobs:
           MATRIX_CONTEXT: ${{ toJson(matrix) }}
         run: echo "$MATRIX_CONTEXT"
 
-      - uses: actions/download-artifact@master
+      - uses: actions/download-artifact@v3
         with:
           name: Packages
           path: pkg
@@ -309,7 +309,7 @@ jobs:
           MATRIX_CONTEXT: ${{ toJson(matrix) }}
         run: echo "$MATRIX_CONTEXT"
 
-      - uses: actions/download-artifact@master
+      - uses: actions/download-artifact@v3
         with:
           name: Packages
           path: pkg
@@ -445,7 +445,7 @@ jobs:
           Choco-Install -PackageName openssl
           Choco-Install -PackageName winflexbison3
         shell: pwsh
-      - uses: actions/download-artifact@master
+      - uses: actions/download-artifact@v3
         with:
           name: Packages
           path: pkg

--- a/.github/workflows/snapshot-master.yml
+++ b/.github/workflows/snapshot-master.yml
@@ -21,11 +21,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/make-snapshot
-      - uses: actions/upload-artifact@master
+      - uses: actions/upload-artifact@v3
         with:
           name: Packages
           path: pkg
-      - uses: actions/upload-artifact@master
+      - uses: actions/upload-artifact@v3
         with:
           name: Info
           path: pkg/info
@@ -100,7 +100,7 @@ jobs:
           MATRIX_CONTEXT: ${{ toJson(matrix) }}
         run: echo "$MATRIX_CONTEXT"
 
-      - uses: actions/download-artifact@master
+      - uses: actions/download-artifact@v3
         with:
           name: Packages
           path: pkg
@@ -271,7 +271,7 @@ jobs:
           MATRIX_CONTEXT: ${{ toJson(matrix) }}
         run: echo "$MATRIX_CONTEXT"
 
-      - uses: actions/download-artifact@master
+      - uses: actions/download-artifact@v3
         with:
           name: Packages
           path: pkg
@@ -424,7 +424,7 @@ jobs:
           Choco-Install -PackageName winflexbison3
         shell: pwsh
 
-      - uses: actions/download-artifact@master
+      - uses: actions/download-artifact@v3
         with:
           name: Packages
           path: pkg
@@ -517,7 +517,7 @@ jobs:
     env:
       ruby_prefix: /tmp/ruby-snapshot
     steps:
-      - uses: actions/download-artifact@master
+      - uses: actions/download-artifact@v3
         with:
           name: Packages
           path: pkg

--- a/.github/workflows/snapshot-ruby_2_7.yml
+++ b/.github/workflows/snapshot-ruby_2_7.yml
@@ -25,11 +25,11 @@ jobs:
           version: 2.7
           fetch-branch: ruby_2_7
           generate-tar-bz2: yes
-      - uses: actions/upload-artifact@master
+      - uses: actions/upload-artifact@v3
         with:
           name: Packages
           path: pkg
-      - uses: actions/upload-artifact@master
+      - uses: actions/upload-artifact@v3
         with:
           name: Info
           path: pkg/info
@@ -103,7 +103,7 @@ jobs:
           MATRIX_CONTEXT: ${{ toJson(matrix) }}
         run: echo "$MATRIX_CONTEXT"
 
-      - uses: actions/download-artifact@master
+      - uses: actions/download-artifact@v3
         with:
           name: Packages
           path: pkg
@@ -225,7 +225,7 @@ jobs:
           MATRIX_CONTEXT: ${{ toJson(matrix) }}
         run: echo "$MATRIX_CONTEXT"
 
-      - uses: actions/download-artifact@master
+      - uses: actions/download-artifact@v3
         with:
           name: Packages
           path: pkg
@@ -339,7 +339,7 @@ jobs:
           Choco-Install -PackageName openssl
           Choco-Install -PackageName winflexbison3
         shell: pwsh
-      - uses: actions/download-artifact@master
+      - uses: actions/download-artifact@v3
         with:
           name: Packages
           path: pkg

--- a/.github/workflows/snapshot-ruby_3_0.yml
+++ b/.github/workflows/snapshot-ruby_3_0.yml
@@ -24,11 +24,11 @@ jobs:
         with:
           version: "3.0"
           fetch-branch: "ruby_3_0"
-      - uses: actions/upload-artifact@master
+      - uses: actions/upload-artifact@v3
         with:
           name: Packages
           path: pkg
-      - uses: actions/upload-artifact@master
+      - uses: actions/upload-artifact@v3
         with:
           name: Info
           path: pkg/info
@@ -102,7 +102,7 @@ jobs:
           MATRIX_CONTEXT: ${{ toJson(matrix) }}
         run: echo "$MATRIX_CONTEXT"
 
-      - uses: actions/download-artifact@master
+      - uses: actions/download-artifact@v3
         with:
           name: Packages
           path: pkg
@@ -224,7 +224,7 @@ jobs:
           MATRIX_CONTEXT: ${{ toJson(matrix) }}
         run: echo "$MATRIX_CONTEXT"
 
-      - uses: actions/download-artifact@master
+      - uses: actions/download-artifact@v3
         with:
           name: Packages
           path: pkg
@@ -338,7 +338,7 @@ jobs:
           Choco-Install -PackageName openssl
           Choco-Install -PackageName winflexbison3
         shell: pwsh
-      - uses: actions/download-artifact@master
+      - uses: actions/download-artifact@v3
         with:
           name: Packages
           path: pkg

--- a/.github/workflows/snapshot-ruby_3_1.yml
+++ b/.github/workflows/snapshot-ruby_3_1.yml
@@ -24,11 +24,11 @@ jobs:
         with:
           version: "3.1"
           fetch-branch: "ruby_3_1"
-      - uses: actions/upload-artifact@master
+      - uses: actions/upload-artifact@v3
         with:
           name: Packages
           path: pkg
-      - uses: actions/upload-artifact@master
+      - uses: actions/upload-artifact@v3
         with:
           name: Info
           path: pkg/info
@@ -102,7 +102,7 @@ jobs:
           MATRIX_CONTEXT: ${{ toJson(matrix) }}
         run: echo "$MATRIX_CONTEXT"
 
-      - uses: actions/download-artifact@master
+      - uses: actions/download-artifact@v3
         with:
           name: Packages
           path: pkg
@@ -220,7 +220,7 @@ jobs:
           MATRIX_CONTEXT: ${{ toJson(matrix) }}
         run: echo "$MATRIX_CONTEXT"
 
-      - uses: actions/download-artifact@master
+      - uses: actions/download-artifact@v3
         with:
           name: Packages
           path: pkg
@@ -376,7 +376,7 @@ jobs:
           Choco-Install -PackageName openssl
           Choco-Install -PackageName winflexbison3
         shell: pwsh
-      - uses: actions/download-artifact@master
+      - uses: actions/download-artifact@v3
         with:
           name: Packages
           path: pkg

--- a/.github/workflows/snapshot-ruby_3_2.yml
+++ b/.github/workflows/snapshot-ruby_3_2.yml
@@ -24,11 +24,11 @@ jobs:
         with:
           version: "3.2"
           fetch-branch: "ruby_3_2"
-      - uses: actions/upload-artifact@master
+      - uses: actions/upload-artifact@v3
         with:
           name: Packages
           path: pkg
-      - uses: actions/upload-artifact@master
+      - uses: actions/upload-artifact@v3
         with:
           name: Info
           path: pkg/info
@@ -103,7 +103,7 @@ jobs:
           MATRIX_CONTEXT: ${{ toJson(matrix) }}
         run: echo "$MATRIX_CONTEXT"
 
-      - uses: actions/download-artifact@master
+      - uses: actions/download-artifact@v3
         with:
           name: Packages
           path: pkg
@@ -274,7 +274,7 @@ jobs:
           MATRIX_CONTEXT: ${{ toJson(matrix) }}
         run: echo "$MATRIX_CONTEXT"
 
-      - uses: actions/download-artifact@master
+      - uses: actions/download-artifact@v3
         with:
           name: Packages
           path: pkg
@@ -427,7 +427,7 @@ jobs:
           Choco-Install -PackageName winflexbison3
         shell: pwsh
 
-      - uses: actions/download-artifact@master
+      - uses: actions/download-artifact@v3
         with:
           name: Packages
           path: pkg
@@ -520,7 +520,7 @@ jobs:
     env:
       ruby_prefix: /tmp/ruby-snapshot
     steps:
-      - uses: actions/download-artifact@master
+      - uses: actions/download-artifact@v3
         with:
           name: Packages
           path: pkg


### PR DESCRIPTION
We should use stable branch for release work because `master` is development branch.