### PR TITLE
Introduce reusing workflow for stable ruby versions

### DIFF
--- a/.github/workflows/ruby_versions.yml
+++ b/.github/workflows/ruby_versions.yml
@@ -13,12 +13,12 @@ on:
         type: string
     outputs:
       versions:
-        description: "Stable Ruby versions"
+        description: "Ruby versions"
         value: ${{ jobs.ruby_versions.outputs.versions }}
 
 jobs:
   ruby_versions:
-    name: Generate stable Ruby versions
+    name: Generate Ruby versions
     runs-on: ubuntu-latest
     outputs:
       versions: ${{ steps.versions.outputs.value }}

--- a/.github/workflows/ruby_versions.yml
+++ b/.github/workflows/ruby_versions.yml
@@ -1,0 +1,32 @@
+name: ruby_versions
+
+on:
+  workflow_call:
+    inputs:
+      engine:
+        description: "The type of Ruby engine"
+        default: "all"
+        type: string
+      versions:
+        description: "Additional Ruby versions"
+        default: "[]"
+        type: string
+    outputs:
+      versions:
+        description: "Stable Ruby versions"
+        value: ${{ jobs.ruby_versions.outputs.versions }}
+
+jobs:
+  ruby_versions:
+    name: Generate stable Ruby versions
+    runs-on: ubuntu-latest
+    outputs:
+      versions: ${{ steps.versions.outputs.value }}
+    steps:
+      - id: versions
+        run: |
+          versions=$(curl -s "https://cache.ruby-lang.org/pub/misc/ci_versions/$ENGINE.json" | jq -c ". + $VERSIONS")
+          echo "value=${versions}" >> $GITHUB_OUTPUT
+        env:
+          ENGINE: ${{ inputs.engine }}
+          VERSIONS: ${{ inputs.versions }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 pkg
-ruby*
+/*.gz
+/*.xz
+/*.zip


### PR DESCRIPTION
This reusing workflow introduce maintained versions like 2.7-3.2 and JRuby, TruffleRuby. 

We always added new version like "3.2" to our libraries like https://github.com/ruby/strscan/pull/59.

After use this workflow. We leave from above work.

## How to use this

```
jobs:
  ruby-versions:
    uses: ruby/actions/.github/workflows/ruby_versions.yml@master
    with:
      engine: "cruby" # default is "all", you can also use "cruby-jruby" and "cruby-truffleruby"
      versions: "[2.5, 2.4]" # You can add old versions with string, not array.

  test:
    needs: ruby-versions
    strategy:
      matrix:
        ruby: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
    runs-on: ubuntu-latest
    steps:
    - uses: actions/checkout@v3
    - name: Set up Ruby
      uses: ruby/setup-ruby@v1
      with:
        ruby-version: ${{ matrix.ruby }}
    - name: Run test
      run: ruby -v
```

Unfortunately, reusing workflow don't support `array` inputs yet. We need to use string for additional versions like "[2.6]".
