### PR TITLE
Introduce minimum version feature for version selection

### DIFF
--- a/.github/workflows/ruby_versions.yml
+++ b/.github/workflows/ruby_versions.yml
@@ -11,6 +11,9 @@ on:
         description: "Additional Ruby versions"
         default: "[]"
         type: string
+      min_version:
+        description: "Minimum Ruby version"
+        type: string
     outputs:
       versions:
         description: "Ruby versions"
@@ -25,8 +28,11 @@ jobs:
     steps:
       - id: versions
         run: |
-          versions=$(curl -s "https://cache.ruby-lang.org/pub/misc/ci_versions/$ENGINE.json" | jq -c ". + $VERSIONS")
+          curl -s "https://cache.ruby-lang.org/pub/misc/ci_versions/$ENGINE.json" -o ci_versions.json
+          ruby -rjson -e "min = JSON.parse(File.read('ci_versions.json')).sort.first; p $MIN_VERSION.step(by: 0.1, to: min.to_f).map{|v| v.round(1).to_s }[..-1]" > versions
+          versions=$(cat ci_versions.json | jq -c ". + $VERSIONS" | jq -c ". + $(cat versions)" | jq -c "sort")
           echo "value=${versions}" >> $GITHUB_OUTPUT
         env:
           ENGINE: ${{ inputs.engine }}
           VERSIONS: ${{ inputs.versions }}
+          MIN_VERSION: ${{ inputs.min_version }}


### PR DESCRIPTION
When we use like:

```
  ruby-versions:
    uses: ruby/actions/.github/workflows/ruby_versions.yml@master
    with:
      engine: "cruby"
      min_version: "2.4"
```

then output is 2.4-3.2 and head versions.