### PR TITLE
Use only installed binaries cache.

### DIFF
--- a/.github/workflows/snapshot-ruby_3_1.yml
+++ b/.github/workflows/snapshot-ruby_3_1.yml
@@ -352,11 +352,11 @@ jobs:
         if: ${{ steps.setup-msys2.outcome == 'success' }}
       - uses: actions/cache@v3
         with:
-          path: C:\vcpkg\downloads
-          key: ${{ runner.os }}-vcpkg-download-${{ matrix.os }}-${{ github.sha }}
+          path: C:\vcpkg\installed
+          key: ${{ runner.os }}-vcpkg-installed-${{ matrix.os }}-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-vcpkg-download-${{ matrix.os }}-
-            ${{ runner.os }}-vcpkg-download-
+            ${{ runner.os }}-vcpkg-installed-${{ matrix.os }}-
+            ${{ runner.os }}-vcpkg-installed-
       - name: Install libraries with vcpkg
         run: |
           vcpkg --triplet x64-windows install openssl readline zlib


### PR DESCRIPTION
https://github.com/ruby/actions/actions/runs/6997319403/job/19034199294#step:13:65

I'm not sure why vcpkg is failed with extracting external tools with download cache.

We should only use installed binaries(built artifact) like OpenSSL.