### PR TITLE
Use MSYS2 bison with Windows snapshot-ruby_3_1.yml & snapshot-ruby_3_2.yml workflow jobs

### DIFF
--- a/.github/workflows/snapshot-ruby_3_1.yml
+++ b/.github/workflows/snapshot-ruby_3_1.yml
@@ -344,8 +344,7 @@ jobs:
         with:
           update: true
           install: >-
-            patch
-        if: ${{ matrix.os != 'windows-2019' }}
+            bison patch
       - name: patch path
         shell: msys2 {0}
         run: echo PATCH=$(cygpath -wa $(command -v patch)) >> $GITHUB_ENV
@@ -360,19 +359,6 @@ jobs:
       - name: Install libraries with vcpkg
         run: |
           vcpkg --triplet x64-windows install openssl readline zlib
-      - uses: actions/cache@v3
-        with:
-          path: C:\Users\runneradmin\AppData\Local\Temp\chocolatey
-          key: ${{ runner.os }}-chocolatey-${{ matrix.os }}-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-chocolatey-${{ matrix.os }}-
-            ${{ runner.os }}-chocolatey-
-      - name: Install libraries with chocolatey
-        run: |
-          # Using Choco-Install for retries, but it doesn't detect failures properly
-          # if you pass multiple package names in a single command.
-          Choco-Install -PackageName winflexbison3
-        shell: pwsh
       - uses: actions/download-artifact@v3
         with:
           name: Packages
@@ -392,7 +378,9 @@ jobs:
       - name: setup env
         # %TEMP% is inconsistent with %TMP% and test-all expects they are consistent.
         # https://github.com/actions/virtual-environments/issues/712#issuecomment-613004302
+        # msys2/setup-msys2 installs MSYS2 to D:/a/_temp/msys64/usr/bin
         run: |
+          set Path=D:/a/_temp/msys64/usr/bin;%Path%
           set | C:\msys64\usr\bin\sort > old.env
           call %VCVARS%
           set TMP=%USERPROFILE%\AppData\Local\Temp
@@ -414,7 +402,7 @@ jobs:
           nmake
           echo ^#^#[endgroup]
         env:
-          YACC: win_bison
+          YACC: bison
       - name: ruby -v
         run: |
           cd snapshot-*

--- a/.github/workflows/snapshot-ruby_3_2.yml
+++ b/.github/workflows/snapshot-ruby_3_2.yml
@@ -398,8 +398,7 @@ jobs:
         with:
           update: true
           install: >-
-            patch
-        if: ${{ env.OS_VER != 'windows-2019' }}
+            bison patch
       - name: patch path
         shell: msys2 {0}
         run: echo PATCH=$(cygpath -wa $(command -v patch)) >> $GITHUB_ENV
@@ -421,19 +420,6 @@ jobs:
       - name: Install libraries with vcpkg
         run: |
           vcpkg --triplet x64-windows install libffi libyaml openssl readline zlib
-      - uses: actions/cache@v3
-        with:
-          path: C:\Users\runneradmin\AppData\Local\Temp\chocolatey
-          key: ${{ runner.os }}-chocolatey-${{ env.OS_VER }}-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-chocolatey-${{ env.OS_VER }}-
-            ${{ runner.os }}-chocolatey-
-      - name: Install libraries with chocolatey
-        run: |
-          # Using Choco-Install for retries, but it doesn't detect failures properly
-          # if you pass multiple package names in a single command.
-          Choco-Install -PackageName winflexbison3
-        shell: pwsh
 
       - uses: actions/download-artifact@v3
         with:
@@ -453,7 +439,6 @@ jobs:
           RUBY_PATCH_URL: "${{ github.event.inputs.RUBY_PATCH_URL }}"
         if: "${{ github.event.inputs.RUBY_PATCH_URL != '' }}"
         working-directory:
-
       - uses: actions/cache@v3
         with:
           path: snapshot-*/.downloaded-cache
@@ -461,7 +446,9 @@ jobs:
       - name: setup env
         # %TEMP% is inconsistent with %TMP% and test-all expects they are consistent.
         # https://github.com/actions/virtual-environments/issues/712#issuecomment-613004302
+        # msys2/setup-msys2 installs MSYS2 to D:/a/_temp/msys64/usr/bin
         run: |
+          set Path=D:/a/_temp/msys64/usr/bin;%Path%
           set VS=${{ matrix.vs }}
           set VCVARS=${{ matrix.vcvars }}
           if not "%VCVARS%" == "" goto :vcset
@@ -492,7 +479,7 @@ jobs:
       - run: nmake extract-extlibs
       - run: nmake
         env:
-          YACC: win_bison
+          YACC: bison
 
       - name: ruby -v
         run: |


### PR DESCRIPTION
I've used MSYS2 bison with ruby-loco's mswin build for quite a while.

This, along with PR #45, should fix failing WIndows CI.