### PR TITLE
Fix build failure of Ruby 3.0 packages

### DIFF
--- a/.github/workflows/snapshot-ruby_3_0.yml
+++ b/.github/workflows/snapshot-ruby_3_0.yml
@@ -335,10 +335,9 @@ jobs:
 
       - name: Install libraries with vcpkg
         run: |
-          vcpkg --triplet x64-windows install readline zlib
+          vcpkg --triplet x64-windows install openssl readline zlib
       - name: Install libraries with chocolatey
         run: |
-          Choco-Install -PackageName openssl
           Choco-Install -PackageName winflexbison3
         shell: pwsh
       - uses: actions/download-artifact@v3

--- a/.github/workflows/snapshot-ruby_3_0.yml
+++ b/.github/workflows/snapshot-ruby_3_0.yml
@@ -333,13 +333,15 @@ jobs:
           MATRIX_CONTEXT: ${{ toJson(matrix) }}
         run: echo "$MATRIX_CONTEXT"
 
+      - uses: msys2/setup-msys2@v2
+        id: setup-msys2
+        with:
+          update: true
+          install: >-
+            bison
       - name: Install libraries with vcpkg
         run: |
           vcpkg --triplet x64-windows install openssl readline zlib
-      - name: Install libraries with chocolatey
-        run: |
-          Choco-Install -PackageName winflexbison3
-        shell: pwsh
       - uses: actions/download-artifact@v3
         with:
           name: Packages
@@ -366,10 +368,11 @@ jobs:
         run: |
           cd snapshot-*
           call "C:\Program Files (x86)\Microsoft Visual Studio\${{ matrix.vs }}\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-          set YACC=win_bison
           nmake up
           nmake
         shell: cmd
+        env:
+          YACC: bison
       - name: nmake test
         run: |
           cd snapshot-*


### PR DESCRIPTION
Recently, we couldn't build Ruby 3.0 with Chocolatey.
```
Choco-Install: D:\a\_temp\194f1413-e505-41e1-931c-1a668f129b7f.ps1:2
Line |
   2 |  Choco-Install -PackageName openssl
     |  ~~~~~~~~~~~~~
     | The term 'Choco-Install' is not recognized as a name of a cmdlet, function, script file, or executable program.
     | Check the spelling of the name, or if a path was included, verify that the path is correct and try again.
```

I replaced them to vcpkg and msys2 packages.