### PR TITLE
Fix step when specifying min_version

### DIFF
--- a/.github/workflows/ruby_versions.yml
+++ b/.github/workflows/ruby_versions.yml
@@ -37,9 +37,14 @@ jobs:
           require 'open-uri'
           versions = JSON.parse(URI(ENV['CI_VERSIONS']).read)
           min = versions.min.to_f
-          if (min_version = ENV['MIN_VERSION'].to_f) > 1.8
+          min_version = ENV['MIN_VERSION'].to_f
+          if min_version > 1.8 && min_version < min
             versions += min_version.step(by: 0.1, to: min).
                         map {|v| sprintf("%.1f",v)} - %w[2.8 2.9]
+          end
+          if min < min_version
+            versions -= min.step(by: 0.1, to: min_version - 0.1).
+                        map {|v| sprintf("%.1f",v)}
           end
           versions.concat(JSON.parse(ENV['VERSIONS'])).tap(&:uniq!).tap(&:sort!)
           output = [


### PR DESCRIPTION
Fixed https://github.com/ruby/error_highlight/pull/40#issuecomment-1879997015
Currently, ci_version returns the following array

```sh
❯ curl https://cache.ruby-lang.org/pub/misc/ci_versions/cruby.json
["3.0","3.1","3.2","3.3","head"]
```

When specifying 3.1 or higher for min_version, it was not set correctly.