### PR TITLE
Tweak macOS runners

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -258,7 +258,7 @@ jobs:
     strategy:
       matrix:
         test_task: [check, test-bundler-parallel, test-bundled-gems]
-        os: [macos-11, macos-12, macos-13]
+        os: [macos-12, macos-13]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -257,8 +257,11 @@ jobs:
     needs: make-snapshot
     strategy:
       matrix:
-        test_task: [check, test-bundler-parallel, test-bundled-gems]
-        os: [macos-12, macos-13]
+        test_task: [check, test-bundled-gems]
+        os: [macos-12, macos-13, macos-arm-oss]
+        include:
+          - os: macos-arm-oss
+            test_task: test-bundler-parallel
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/snapshot-master.yml
+++ b/.github/workflows/snapshot-master.yml
@@ -251,8 +251,11 @@ jobs:
     needs: make-snapshot
     strategy:
       matrix:
-        test_task: [check, test-bundler-parallel, test-bundled-gems]
-        os: [macos-12, macos-13]
+        test_task: [check, test-bundled-gems]
+        os: [macos-12, macos-13, macos-arm-oss]
+        include:
+          - os: macos-arm-oss
+            test_task: test-bundler-parallel
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/snapshot-master.yml
+++ b/.github/workflows/snapshot-master.yml
@@ -252,7 +252,7 @@ jobs:
     strategy:
       matrix:
         test_task: [check, test-bundler-parallel, test-bundled-gems]
-        os: [macos-11, macos-12, macos-13]
+        os: [macos-12, macos-13]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/snapshot-ruby_3_0.yml
+++ b/.github/workflows/snapshot-ruby_3_0.yml
@@ -194,11 +194,11 @@ jobs:
     strategy:
       matrix:
         test_task: [check, test-bundled-gems]
-        os: [macos-11, macos-12, macos-13]
+        os: [macos-12, macos-13]
         include:
           # macos-12 with Ruby 3.0 cannot pass test-bundler-parallel
           # It mixed system ruby and build artifacts.
-          - os: macos-11
+          - os: macos-13
             test_task: test-bundler-parallel
       fail-fast: false
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/snapshot-ruby_3_0.yml
+++ b/.github/workflows/snapshot-ruby_3_0.yml
@@ -194,11 +194,9 @@ jobs:
     strategy:
       matrix:
         test_task: [check, test-bundled-gems]
-        os: [macos-12, macos-13]
+        os: [macos-12, macos-13, macos-arm-oss]
         include:
-          # macos-12 with Ruby 3.0 cannot pass test-bundler-parallel
-          # It mixed system ruby and build artifacts.
-          - os: macos-13
+          - os: macos-arm-oss
             test_task: test-bundler-parallel
       fail-fast: false
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/snapshot-ruby_3_1.yml
+++ b/.github/workflows/snapshot-ruby_3_1.yml
@@ -189,8 +189,11 @@ jobs:
     needs: make-snapshot
     strategy:
       matrix:
-        test_task: [check, test-bundler-parallel, test-bundled-gems]
-        os: [macos-12, macos-13]
+        test_task: [check, test-bundled-gems]
+        os: [macos-12, macos-13, macos-arm-oss]
+        include:
+          - os: macos-arm-oss
+            test_task: test-bundler-parallel
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/snapshot-ruby_3_1.yml
+++ b/.github/workflows/snapshot-ruby_3_1.yml
@@ -190,7 +190,7 @@ jobs:
     strategy:
       matrix:
         test_task: [check, test-bundler-parallel, test-bundled-gems]
-        os: [macos-11, macos-12, macos-13]
+        os: [macos-12, macos-13]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/snapshot-ruby_3_2.yml
+++ b/.github/workflows/snapshot-ruby_3_2.yml
@@ -253,8 +253,11 @@ jobs:
     needs: make-snapshot
     strategy:
       matrix:
-        test_task: [check, test-bundler-parallel, test-bundled-gems]
-        os: [macos-12, macos-13]
+        test_task: [check, test-bundled-gems]
+        os: [macos-12, macos-13, macos-arm-oss]
+        include:
+          - os: macos-arm-oss
+            test_task: test-bundler-parallel
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/snapshot-ruby_3_2.yml
+++ b/.github/workflows/snapshot-ruby_3_2.yml
@@ -254,7 +254,7 @@ jobs:
     strategy:
       matrix:
         test_task: [check, test-bundler-parallel, test-bundled-gems]
-        os: [macos-11, macos-12, macos-13]
+        os: [macos-12, macos-13]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/snapshot-ruby_3_3.yml
+++ b/.github/workflows/snapshot-ruby_3_3.yml
@@ -253,8 +253,11 @@ jobs:
     needs: make-snapshot
     strategy:
       matrix:
-        test_task: [check, test-bundler-parallel, test-bundled-gems]
-        os: [macos-12, macos-13]
+        test_task: [check, test-bundled-gems]
+        os: [macos-12, macos-13, macos-arm-oss]
+        include:
+          - os: macos-arm-oss
+            test_task: test-bundler-parallel
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/snapshot-ruby_3_3.yml
+++ b/.github/workflows/snapshot-ruby_3_3.yml
@@ -254,7 +254,7 @@ jobs:
     strategy:
       matrix:
         test_task: [check, test-bundler-parallel, test-bundled-gems]
-        os: [macos-11, macos-12, macos-13]
+        os: [macos-12, macos-13]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
* Retired `macos-11` (= Big Sur) runner
* Added `macos-arm-oss` (= Ventura with Apple Silicon) runner
  * Ignore to run `test-bundler-parallel` on Intel macOS runners for performance reason.