### PR TITLE
Print git sha using RUBY_REVISION

### DIFF
--- a/.github/workflows/snapshot-master.yml
+++ b/.github/workflows/snapshot-master.yml
@@ -236,7 +236,7 @@ jobs:
         run: cd snapshot-*/ && sudo make $JOBS install
         if: matrix.test_task == 'check'
       - name: ruby -v
-        run: ruby -v
+        run: /usr/local/bin/ruby -v
         if: matrix.test_task == 'check'
       - name: Show .local
         run: find $HOME/.local -ls
@@ -254,7 +254,7 @@ jobs:
         if: failure()
       - name: Get ruby/ruby sha
         id: ruby_sha
-        run: cd snapshot-*/ && echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+        run: /usr/local/bin/ruby -e 'puts "sha=#{RUBY_REVISION}"' >> $GITHUB_OUTPUT
         if: failure()
       - uses: ruby/action-slack@v3.2.1
         with:


### PR DESCRIPTION
`git` may not be available, so I want to use the installed Ruby to print the revision.

<img width="637" alt="Screenshot 2024-02-27 at 11 06 25" src="https://github.com/ruby/actions/assets/3138447/163a31b4-43f1-463a-b9d4-9555d3a7f393">

Also, the `ruby -v` step prints the version of baseruby after `make install`, but I suspect we wanted to print the installed Ruby version. So I fixed that step as well.