### PR TITLE
Use ./ruby to print RUBY_REVISION

### DIFF
--- a/.github/workflows/snapshot-master.yml
+++ b/.github/workflows/snapshot-master.yml
@@ -254,7 +254,7 @@ jobs:
         if: failure()
       - name: Get ruby/ruby sha
         id: ruby_sha
-        run: /usr/local/bin/ruby -e 'puts "sha=#{RUBY_REVISION}"' >> $GITHUB_OUTPUT
+        run: cd snapshot-*/ && ./ruby -e 'puts "sha=#{RUBY_REVISION}"' >> $GITHUB_OUTPUT
         if: failure()
       - uses: ruby/action-slack@v3.2.1
         with:


### PR DESCRIPTION
Tests run before `make install`, so `/usr/local/bin/ruby` may not be available when a failure is notified.