### PR TITLE
XDG_CACHE_HOME is also writable by users

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -202,6 +202,7 @@ jobs:
         run: |
           mkdir -p $HOME/.gem
           chmod -v a-w $HOME $HOME/.config
+          chmod -v a+w $HOME/.cache
           sudo chmod -R a-w /usr/share
           sudo bash -c 'IFS=:; for d in '"$PATH"'; do chmod -v a-w $d; done' || :
       - name: mkdir ~/.local


### PR DESCRIPTION
Try to fix https://github.com/ruby/actions/actions/runs/9107030569/job/25035287797

We should allow to write to `XDG_CACHE_HOME` by users.