### PR TITLE
Rolling update with ubuntu-22.04 and ubuntu-20.04

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -127,7 +127,7 @@ jobs:
     strategy:
       matrix:
         test_task: [check, test-bundler-parallel, test-bundled-gems]
-        os: [ubuntu-22.04, ubuntu-20.04]
+        os: [ubuntu-24.04, ubuntu-22.04]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/snapshot-master.yml
+++ b/.github/workflows/snapshot-master.yml
@@ -73,7 +73,7 @@ jobs:
     strategy:
       matrix:
         test_task: [check, test-bundler-parallel, test-bundled-gems]
-        os: [ubuntu-22.04, ubuntu-20.04]
+        os: [ubuntu-24.04, ubuntu-22.04]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -538,7 +538,7 @@ jobs:
 
   non_development:
     needs: make-snapshot
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       ruby_prefix: /tmp/ruby-snapshot
     steps:

--- a/.github/workflows/snapshot-ruby_3_1.yml
+++ b/.github/workflows/snapshot-ruby_3_1.yml
@@ -75,7 +75,7 @@ jobs:
     strategy:
       matrix:
         test_task: [check, test-bundler-parallel, test-bundled-gems]
-        os: [ubuntu-22.04, ubuntu-20.04]
+        os: [ubuntu-24.04, ubuntu-22.04]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/snapshot-ruby_3_2.yml
+++ b/.github/workflows/snapshot-ruby_3_2.yml
@@ -76,7 +76,7 @@ jobs:
     strategy:
       matrix:
         test_task: [check, test-bundler-parallel, test-bundled-gems]
-        os: [ubuntu-22.04, ubuntu-20.04]
+        os: [ubuntu-24.04, ubuntu-22.04]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -517,7 +517,7 @@ jobs:
 
   non_development:
     needs: make-snapshot
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       ruby_prefix: /tmp/ruby-snapshot
     steps:

--- a/.github/workflows/snapshot-ruby_3_3.yml
+++ b/.github/workflows/snapshot-ruby_3_3.yml
@@ -76,7 +76,7 @@ jobs:
     strategy:
       matrix:
         test_task: [check, test-bundler-parallel, test-bundled-gems]
-        os: [ubuntu-22.04, ubuntu-20.04]
+        os: [ubuntu-24.04, ubuntu-22.04]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -520,7 +520,7 @@ jobs:
 
   non_development:
     needs: make-snapshot
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       ruby_prefix: /tmp/ruby-snapshot
     steps:

--- a/.github/workflows/snapshot-ruby_3_4.yml
+++ b/.github/workflows/snapshot-ruby_3_4.yml
@@ -76,7 +76,7 @@ jobs:
     strategy:
       matrix:
         test_task: [check, test-bundler-parallel, test-bundled-gems]
-        os: [ubuntu-22.04, ubuntu-20.04]
+        os: [ubuntu-24.04, ubuntu-22.04]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -541,7 +541,7 @@ jobs:
 
   non_development:
     needs: make-snapshot
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       ruby_prefix: /tmp/ruby-snapshot
     steps:


### PR DESCRIPTION
from https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/

We shouldn't use `ubuntu-20.04`. I updated `ubuntu-22.04` to `ubuntu-24.04` and `ubuntu-20.04` to `ubuntu-22.04`.