### PR TITLE
Fix Ruby versions exclusion in workflow

### DIFF
--- a/.github/workflows/ruby_versions.yml
+++ b/.github/workflows/ruby_versions.yml
@@ -43,8 +43,7 @@ jobs:
                         map {|v| sprintf("%.1f",v)} - %w[2.8 2.9]
           end
           if min < min_version
-            versions -= min.step(by: 0.1, to: min_version - 0.1).
-                        map {|v| sprintf("%.1f",v)}
+            versions.reject! {|v| v.match?(/^\d/) && v.to_f < min_version}
           end
           versions.concat(JSON.parse(ENV['VERSIONS'])).tap(&:uniq!).tap(&:sort!)
           output = [


### PR DESCRIPTION
## Problem
When setting `min_version: 3.3` in the workflow, Ruby 3.2 was still included in the versions list when it should have been excluded.

The issue was caused by a floating point precision problem in the original implementation. When calculating `min.step(by: 0.1, to: min_version - 0.1)`, if `min` is 3.2 and `min_version` is 3.3, the range becomes `3.2..3.2`, which sometimes doesn't iterate at all due to floating point precision.

## Solution
Replace the step-based exclusion logic with a direct version comparison that explicitly removes any numeric version below the specified minimum version:

```ruby
versions.reject! {|v| v.match?(/^\d/) && v.to_f < min_version}
```

## Tested
Confirmed that with `min_version: 3.3`, Ruby 3.2 is properly excluded from the versions list.