### PR TITLE
Add rbs,repl_type_completor as allowed bundled gem failures

### DIFF
--- a/.github/workflows/snapshot-master.yml
+++ b/.github/workflows/snapshot-master.yml
@@ -14,7 +14,7 @@ on:
         required: false
 
 env:
-  TEST_BUNDLED_GEMS_ALLOW_FAILURES: "typeprof"
+  TEST_BUNDLED_GEMS_ALLOW_FAILURES: "typeprof,rbs,repl_type_completor"
 
 jobs:
   make-snapshot:


### PR DESCRIPTION
This was already done for all ruby/ruby workflows when core Set was added.