### PR TITLE
Use windows-2022 image instead of windows-2019

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -382,8 +382,9 @@ jobs:
     needs: make-snapshot
     strategy:
       matrix:
-        os: [windows-2019]
-        vs: [2019]
+        os: [windows-2022]
+        vs: [2022]
+        vcvars: ['10.0.22621.0 -vcvars_ver=14.2']
         test_task: [test]
       fail-fast: false
     runs-on: ${{ matrix.os }}
@@ -447,13 +448,13 @@ jobs:
       - name: configure
         run: |
           cd ruby-*
-          call "C:\Program Files (x86)\Microsoft Visual Studio\${{ matrix.vs }}\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+          call "C:\Program Files (x86)\Microsoft Visual Studio\${{ matrix.vs }}\Enterprise\VC\Auxiliary\Build\vcvars64.bat" ${{ matrix.vcvars || ''}}
           win32/configure.bat --disable-install-doc --without-ext=+,dbm,gdbm --enable-bundled-libffi --with-opt-dir=C:/vcpkg/installed/x64-windows
         shell: cmd
       - name: nmake
         run: |
           cd ruby-*
-          call "C:\Program Files (x86)\Microsoft Visual Studio\${{ matrix.vs }}\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+          call "C:\Program Files (x86)\Microsoft Visual Studio\${{ matrix.vs }}\Enterprise\VC\Auxiliary\Build\vcvars64.bat" ${{ matrix.vcvars || ''}}
           nmake up
           nmake
         shell: cmd
@@ -462,7 +463,7 @@ jobs:
       - name: nmake test
         run: |
           cd ruby-*
-          call "C:\Program Files (x86)\Microsoft Visual Studio\${{ matrix.vs }}\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+          call "C:\Program Files (x86)\Microsoft Visual Studio\${{ matrix.vs }}\Enterprise\VC\Auxiliary\Build\vcvars64.bat" ${{ matrix.vcvars || '' }}
           nmake ${{ matrix.test_task }}
         shell: cmd
         env:

--- a/.github/workflows/snapshot-master.yml
+++ b/.github/workflows/snapshot-master.yml
@@ -360,19 +360,20 @@ jobs:
     strategy:
       matrix:
         include:
-          - vs: 2019
-          # - vs: 2022
+          - os: 2022
+            vs: 2022
+            vcvars: '10.0.22621.0 -vcvars_ver=14.2'
       fail-fast: false
-    runs-on: windows-${{ matrix.vs < 2022 && '2019' || matrix.vs }}
+    runs-on: windows-${{ matrix.os }}
     defaults:
       run:
         shell: cmd
         working-directory: build
-    name: VisualStudio ${{ matrix.vs }}
+    name: Windows ${{ matrix.os }}
     env:
       GITPULLOPTIONS: --no-tags origin ${{github.ref}}
       PATCH: C:\msys64\usr\bin\patch.exe
-      OS_VER: windows-${{ matrix.vs < 2022 && '2019' || matrix.vs }}
+      OS_VER: windows-${{ matrix.os }}
       # see https://github.com/ruby/ruby/commit/9ff4399decef0036897d3cfb9ac2c710dea913ca
       OPENSSL_MODULES: C:\vcpkg\installed\x64-windows\bin
     steps:
@@ -411,7 +412,6 @@ jobs:
           update: true
           install: >-
             patch
-        if: ${{ env.OS_VER != 'windows-2019' }}
       - name: patch path
         shell: msys2 {0}
         run: echo PATCH=$(cygpath -wa $(command -v patch)) >> $GITHUB_ENV
@@ -461,14 +461,12 @@ jobs:
         # %TEMP% is inconsistent with %TMP% and test-all expects they are consistent.
         # https://github.com/actions/virtual-environments/issues/712#issuecomment-613004302
         run: |
-          set VS=${{ matrix.vs }}
-          set VCVARS=${{ matrix.vcvars }}
           if not "%VCVARS%" == "" goto :vcset
-            set VCVARS="C:\Program Files (x86)\Microsoft Visual Studio\%VS%\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-            if not exist %VCVARS% set VCVARS="C:\Program Files\Microsoft Visual Studio\%VS%\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+            set VCVARS="C:\Program Files (x86)\Microsoft Visual Studio\${{ matrix.vs }}\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+            if not exist %VCVARS% set VCVARS="C:\Program Files\Microsoft Visual Studio\${{ matrix.vs }}\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
           :vcset
           set | C:\msys64\usr\bin\sort > old.env
-          call %VCVARS%
+          call %VCVARS% ${{ matrix.vcvars }}
           set TMP=%USERPROFILE%\AppData\Local\Temp
           set TEMP=%USERPROFILE%\AppData\Local\Temp
           set /a TEST_JOBS=(15 * %NUMBER_OF_PROCESSORS% / 10) > nul

--- a/.github/workflows/snapshot-ruby_3_2.yml
+++ b/.github/workflows/snapshot-ruby_3_2.yml
@@ -356,19 +356,22 @@ jobs:
     strategy:
       matrix:
         include:
-          - vs: 2019
-          # - vs: 2022
+          - os: 2022
+            vs: 2022
+            vcvars: '10.0.22621.0 -vcvars_ver=14.2'
       fail-fast: false
-    runs-on: windows-${{ matrix.vs < 2022 && '2019' || matrix.vs }}
+    runs-on: windows-${{ matrix.os }}
     defaults:
       run:
         shell: cmd
         working-directory: build
-    name: VisualStudio ${{ matrix.vs }}
+    name: Windows ${{ matrix.os }}
     env:
       GITPULLOPTIONS: --no-tags origin ${{github.ref}}
       PATCH: C:\msys64\usr\bin\patch.exe
-      OS_VER: windows-${{ matrix.vs < 2022 && '2019' || matrix.vs }}
+      OS_VER: windows-${{ matrix.os }}
+      # see https://github.com/ruby/ruby/commit/9ff4399decef0036897d3cfb9ac2c710dea913ca
+      OPENSSL_MODULES: C:\vcpkg\installed\x64-windows\bin
     steps:
       - run: md build
         working-directory:
@@ -404,7 +407,7 @@ jobs:
         with:
           update: true
           install: >-
-            bison patch
+            patch
       - name: patch path
         shell: msys2 {0}
         run: echo PATCH=$(cygpath -wa $(command -v patch)) >> $GITHUB_ENV
@@ -445,6 +448,7 @@ jobs:
           RUBY_PATCH_URL: "${{ github.event.inputs.RUBY_PATCH_URL }}"
         if: "${{ github.event.inputs.RUBY_PATCH_URL != '' }}"
         working-directory:
+
       - uses: actions/cache@v4
         with:
           path: snapshot-*/.downloaded-cache
@@ -452,17 +456,13 @@ jobs:
       - name: setup env
         # %TEMP% is inconsistent with %TMP% and test-all expects they are consistent.
         # https://github.com/actions/virtual-environments/issues/712#issuecomment-613004302
-        # msys2/setup-msys2 installs MSYS2 to D:/a/_temp/msys64/usr/bin
         run: |
-          set Path=D:/a/_temp/msys64/usr/bin;%Path%
-          set VS=${{ matrix.vs }}
-          set VCVARS=${{ matrix.vcvars }}
           if not "%VCVARS%" == "" goto :vcset
-            set VCVARS="C:\Program Files (x86)\Microsoft Visual Studio\%VS%\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-            if not exist %VCVARS% set VCVARS="C:\Program Files\Microsoft Visual Studio\%VS%\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+            set VCVARS="C:\Program Files (x86)\Microsoft Visual Studio\${{ matrix.vs }}\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+            if not exist %VCVARS% set VCVARS="C:\Program Files\Microsoft Visual Studio\${{ matrix.vs }}\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
           :vcset
           set | C:\msys64\usr\bin\sort > old.env
-          call %VCVARS%
+          call %VCVARS% ${{ matrix.vcvars }}
           set TMP=%USERPROFILE%\AppData\Local\Temp
           set TEMP=%USERPROFILE%\AppData\Local\Temp
           set /a TEST_JOBS=(15 * %NUMBER_OF_PROCESSORS% / 10) > nul
@@ -485,7 +485,7 @@ jobs:
       - run: nmake extract-extlibs
       - run: nmake
         env:
-          YACC: bison
+          YACC: win_bison
 
       - name: ruby -v
         run: |

--- a/.github/workflows/snapshot-ruby_3_3.yml
+++ b/.github/workflows/snapshot-ruby_3_3.yml
@@ -357,19 +357,20 @@ jobs:
     strategy:
       matrix:
         include:
-          - vs: 2019
-          # - vs: 2022
+          - os: 2022
+            vs: 2022
+            vcvars: '10.0.22621.0 -vcvars_ver=14.2'
       fail-fast: false
-    runs-on: windows-${{ matrix.vs < 2022 && '2019' || matrix.vs }}
+    runs-on: windows-${{ matrix.os }}
     defaults:
       run:
         shell: cmd
         working-directory: build
-    name: VisualStudio ${{ matrix.vs }}
+    name: Windows ${{ matrix.os }}
     env:
       GITPULLOPTIONS: --no-tags origin ${{github.ref}}
       PATCH: C:\msys64\usr\bin\patch.exe
-      OS_VER: windows-${{ matrix.vs < 2022 && '2019' || matrix.vs }}
+      OS_VER: windows-${{ matrix.os }}
       # see https://github.com/ruby/ruby/commit/9ff4399decef0036897d3cfb9ac2c710dea913ca
       OPENSSL_MODULES: C:\vcpkg\installed\x64-windows\bin
     steps:
@@ -408,7 +409,6 @@ jobs:
           update: true
           install: >-
             patch
-        if: ${{ env.OS_VER != 'windows-2019' }}
       - name: patch path
         shell: msys2 {0}
         run: echo PATCH=$(cygpath -wa $(command -v patch)) >> $GITHUB_ENV
@@ -458,14 +458,12 @@ jobs:
         # %TEMP% is inconsistent with %TMP% and test-all expects they are consistent.
         # https://github.com/actions/virtual-environments/issues/712#issuecomment-613004302
         run: |
-          set VS=${{ matrix.vs }}
-          set VCVARS=${{ matrix.vcvars }}
           if not "%VCVARS%" == "" goto :vcset
-            set VCVARS="C:\Program Files (x86)\Microsoft Visual Studio\%VS%\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-            if not exist %VCVARS% set VCVARS="C:\Program Files\Microsoft Visual Studio\%VS%\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+            set VCVARS="C:\Program Files (x86)\Microsoft Visual Studio\${{ matrix.vs }}\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+            if not exist %VCVARS% set VCVARS="C:\Program Files\Microsoft Visual Studio\${{ matrix.vs }}\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
           :vcset
           set | C:\msys64\usr\bin\sort > old.env
-          call %VCVARS%
+          call %VCVARS% ${{ matrix.vcvars }}
           set TMP=%USERPROFILE%\AppData\Local\Temp
           set TEMP=%USERPROFILE%\AppData\Local\Temp
           set /a TEST_JOBS=(15 * %NUMBER_OF_PROCESSORS% / 10) > nul

--- a/.github/workflows/snapshot-ruby_3_4.yml
+++ b/.github/workflows/snapshot-ruby_3_4.yml
@@ -378,19 +378,20 @@ jobs:
     strategy:
       matrix:
         include:
-          - vs: 2019
-          # - vs: 2022
+          - os: 2022
+            vs: 2022
+            vcvars: '10.0.22621.0 -vcvars_ver=14.2'
       fail-fast: false
-    runs-on: windows-${{ matrix.vs < 2022 && '2019' || matrix.vs }}
+    runs-on: windows-${{ matrix.os }}
     defaults:
       run:
         shell: cmd
         working-directory: build
-    name: VisualStudio ${{ matrix.vs }}
+    name: Windows ${{ matrix.os }}
     env:
       GITPULLOPTIONS: --no-tags origin ${{github.ref}}
       PATCH: C:\msys64\usr\bin\patch.exe
-      OS_VER: windows-${{ matrix.vs < 2022 && '2019' || matrix.vs }}
+      OS_VER: windows-${{ matrix.os }}
       # see https://github.com/ruby/ruby/commit/9ff4399decef0036897d3cfb9ac2c710dea913ca
       OPENSSL_MODULES: C:\vcpkg\installed\x64-windows\bin
     steps:
@@ -429,7 +430,6 @@ jobs:
           update: true
           install: >-
             patch
-        if: ${{ env.OS_VER != 'windows-2019' }}
       - name: patch path
         shell: msys2 {0}
         run: echo PATCH=$(cygpath -wa $(command -v patch)) >> $GITHUB_ENV
@@ -479,14 +479,12 @@ jobs:
         # %TEMP% is inconsistent with %TMP% and test-all expects they are consistent.
         # https://github.com/actions/virtual-environments/issues/712#issuecomment-613004302
         run: |
-          set VS=${{ matrix.vs }}
-          set VCVARS=${{ matrix.vcvars }}
           if not "%VCVARS%" == "" goto :vcset
-            set VCVARS="C:\Program Files (x86)\Microsoft Visual Studio\%VS%\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-            if not exist %VCVARS% set VCVARS="C:\Program Files\Microsoft Visual Studio\%VS%\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+            set VCVARS="C:\Program Files (x86)\Microsoft Visual Studio\${{ matrix.vs }}\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+            if not exist %VCVARS% set VCVARS="C:\Program Files\Microsoft Visual Studio\${{ matrix.vs }}\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
           :vcset
           set | C:\msys64\usr\bin\sort > old.env
-          call %VCVARS%
+          call %VCVARS% ${{ matrix.vcvars }}
           set TMP=%USERPROFILE%\AppData\Local\Temp
           set TEMP=%USERPROFILE%\AppData\Local\Temp
           set /a TEST_JOBS=(15 * %NUMBER_OF_PROCESSORS% / 10) > nul


### PR DESCRIPTION
We need to use winsdk-10.0.22621.0 and -vcvars_ver=14.2 because the defautl version of vs2022 is broken now.