### PR TITLE
Add a workaround for gcov's bug

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -31,7 +31,7 @@ jobs:
           sudo bash -c 'IFS=:; for d in '"$PATH"'; do chmod -v a-w $d; done' || :
       - run: cd ruby && ./autogen.sh
       - name: Configure with gcov
-        run: cd ruby && ./configure --enable-gcov CC=gcc
+        run: cd ruby && ./configure ./configure ac_cv_func_vfork=no --enable-gcov CC=gcc # ac_cv_func_vfork=no is needed to work around: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=118553
       - name: Setup coverage tools
         run: cd ruby && make update-coverage
       - name: Build


### PR DESCRIPTION
Calling vfork stops the coverage measurement.
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=118553