### PR TITLE
Removed download cache of vcpkg

### DIFF
--- a/.github/workflows/snapshot-master.yml
+++ b/.github/workflows/snapshot-master.yml
@@ -427,13 +427,6 @@ jobs:
         if: ${{ steps.setup-msys2.outcome == 'success' }}
       - uses: actions/cache@v4
         with:
-          path: C:\vcpkg\downloads
-          key: ${{ runner.os }}-vcpkg-download-${{ env.OS_VER }}-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-vcpkg-download-${{ env.OS_VER }}-
-            ${{ runner.os }}-vcpkg-download-
-      - uses: actions/cache@v4
-        with:
           path: C:\vcpkg\installed
           key: ${{ runner.os }}-vcpkg-installed-${{ env.OS_VER }}-${{ github.sha }}
           restore-keys: |

--- a/.github/workflows/snapshot-ruby_3_2.yml
+++ b/.github/workflows/snapshot-ruby_3_2.yml
@@ -414,13 +414,6 @@ jobs:
         if: ${{ steps.setup-msys2.outcome == 'success' }}
       - uses: actions/cache@v4
         with:
-          path: C:\vcpkg\downloads
-          key: ${{ runner.os }}-vcpkg-download-${{ env.OS_VER }}-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-vcpkg-download-${{ env.OS_VER }}-
-            ${{ runner.os }}-vcpkg-download-
-      - uses: actions/cache@v4
-        with:
           path: C:\vcpkg\installed
           key: ${{ runner.os }}-vcpkg-installed-${{ env.OS_VER }}-${{ github.sha }}
           restore-keys: |

--- a/.github/workflows/snapshot-ruby_3_3.yml
+++ b/.github/workflows/snapshot-ruby_3_3.yml
@@ -415,13 +415,6 @@ jobs:
         if: ${{ steps.setup-msys2.outcome == 'success' }}
       - uses: actions/cache@v4
         with:
-          path: C:\vcpkg\downloads
-          key: ${{ runner.os }}-vcpkg-download-${{ env.OS_VER }}-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-vcpkg-download-${{ env.OS_VER }}-
-            ${{ runner.os }}-vcpkg-download-
-      - uses: actions/cache@v4
-        with:
           path: C:\vcpkg\installed
           key: ${{ runner.os }}-vcpkg-installed-${{ env.OS_VER }}-${{ github.sha }}
           restore-keys: |

--- a/.github/workflows/snapshot-ruby_3_4.yml
+++ b/.github/workflows/snapshot-ruby_3_4.yml
@@ -436,13 +436,6 @@ jobs:
         if: ${{ steps.setup-msys2.outcome == 'success' }}
       - uses: actions/cache@v4
         with:
-          path: C:\vcpkg\downloads
-          key: ${{ runner.os }}-vcpkg-download-${{ env.OS_VER }}-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-vcpkg-download-${{ env.OS_VER }}-
-            ${{ runner.os }}-vcpkg-download-
-      - uses: actions/cache@v4
-        with:
           path: C:\vcpkg\installed
           key: ${{ runner.os }}-vcpkg-installed-${{ env.OS_VER }}-${{ github.sha }}
           restore-keys: |


### PR DESCRIPTION
It's unnecessary to next jobs. We should reduce cache usage on ruby/actions