### PR TITLE
Drop `--job-status=normal` from Windows nmake check

### DIFF
--- a/.github/workflows/snapshot-master.yml
+++ b/.github/workflows/snapshot-master.yml
@@ -496,7 +496,7 @@ jobs:
         timeout-minutes: 5
       - run: nmake ${{ matrix.test_task }}
         env:
-          RUBY_TESTOPTS: -j${{env.TEST_JOBS}} --job-status=normal
+          RUBY_TESTOPTS: -j${{env.TEST_JOBS}}
         timeout-minutes: 70
         continue-on-error: ${{ matrix.continue-on-error || false }}
 

--- a/.github/workflows/snapshot-ruby_4_0.yml
+++ b/.github/workflows/snapshot-ruby_4_0.yml
@@ -499,7 +499,7 @@ jobs:
         timeout-minutes: 5
       - run: nmake ${{ matrix.test_task }}
         env:
-          RUBY_TESTOPTS: -j${{env.TEST_JOBS}} --job-status=normal
+          RUBY_TESTOPTS: -j${{env.TEST_JOBS}}
         timeout-minutes: 70
         continue-on-error: ${{ matrix.continue-on-error || false }}
 


### PR DESCRIPTION
The option belongs to test/unit and is not understood by bootstraptest's runner.rb, which loads it as a script and aborts the check target.
