### PR TITLE
ci: declare workflow-level `contents: read` on the 11 remaining workflows

### DIFF
--- a/.github/workflows/bundled_gems.yml
+++ b/.github/workflows/bundled_gems.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: '15 7 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   Update-bundled_gems:
 

--- a/.github/workflows/remove-tmp-package.yml
+++ b/.github/workflows/remove-tmp-package.yml
@@ -11,6 +11,9 @@ on:
         required: true
         default: 3.0.0-preview1-draft
 
+permissions:
+  contents: read
+
 jobs:
   remove:
     runs-on: ubuntu-latest

--- a/.github/workflows/test_ruby_versions.yml
+++ b/.github/workflows/test_ruby_versions.yml
@@ -10,6 +10,9 @@ on:
       - '.github/workflows/ruby_versions.yml'
       - '.github/workflows/test_ruby_versions.yml'
 
+permissions:
+  contents: read
+
 jobs:
   call_defaults:
     uses: ./.github/workflows/ruby_versions.yml

--- a/.github/workflows/update_ci_versions.yml
+++ b/.github/workflows/update_ci_versions.yml
@@ -6,6 +6,9 @@ on:
   repository_dispatch:
     types: "update_ci_versions"
 
+permissions:
+  contents: read
+
 jobs:
   update_ci_versions:
     runs-on: ubuntu-latest

--- a/.github/workflows/update_index.yml
+++ b/.github/workflows/update_index.yml
@@ -7,6 +7,9 @@ on:
     types: "update_index"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   update_index:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` on the 11 workflows in `.github/workflows/` that don't actually need any write scope:

- `bundled_gems.yml`, `coverage.yml`, `doxygen.yml`, `test_ruby_versions.yml`, `update_ci_versions.yml`: test, lint, and coverage workflows. No GitHub API call beyond the initial checkout.
- `snapshot-master.yml`, `snapshot-ruby_3_3.yml`, `snapshot-ruby_3_4.yml`, `snapshot-ruby_4_0.yml`: build the Ruby snapshot tarballs and upload them as workflow artifacts. No GitHub API mutation.
- `remove-tmp-package.yml`: removes files from `s3://ftp.r-l.o/pub/tmp/` and purges the Fastly cache. AWS credentials only, no `GITHUB_TOKEN` use.
- `update_index.yml`: updates the index via AWS S3 credentials; no `GITHUB_TOKEN` use.

`draft-release.yml` is left implicit on purpose; it needs write scopes that are best declared by a maintainer who knows the release flow.

## Why

CVE-2025-30066 (March 2025 `tj-actions/changed-files` supply-chain compromise) exfiltrated `GITHUB_TOKEN` from workflow logs and the leaked token retained whatever scope was issued at the workflow level. Pinning per workflow caps that runtime authority irrespective of the repo or org default, gives drift protection if the default ever widens, and is credited per-file by the OpenSSF Scorecard `Token-Permissions` check.

YAML validated locally with `yaml.safe_load` on each touched file.