### PR TITLE
ci: declare workflow-level contents: read on coverage and doxygen

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -6,6 +6,9 @@ on:
     types: "coverage"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   latest:
     runs-on: ubuntu-latest

--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -6,6 +6,9 @@ on:
     types: "doxygen"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   latest:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` at the workflow level. The workflow runs checks only; no GitHub API writes.

Same post-CVE-2025-30066 (`tj-actions/changed-files`) supply-chain hardening pattern. YAML validated locally with `yaml.safe_load`.