### PR TITLE
Clone the snapshot source with LF line endings

### DIFF
--- a/.github/workflows/mswin-build.yml
+++ b/.github/workflows/mswin-build.yml
@@ -64,7 +64,13 @@ jobs:
             tar xf ruby-src.tar.gz
             mv "ruby-$TARGET_VERSION" src
           else
-            git clone --depth=1 https://github.com/ruby/ruby src
+            # Check out with LF like ruby/ruby's own CI does.  The
+            # runner's git defaults to core.autocrlf=true, and the
+            # prism-based rbinc generation (tool/dump_ast.c plus
+            # tool/mk_builtin_loader.rb) misassociates Primitive.cexpr!
+            # with its enclosing method on CRLF sources, which breaks
+            # the build with C2065 in array.c.
+            git clone -c core.autocrlf=false -c core.eol=lf --depth=1 https://github.com/ruby/ruby src
           fi
         shell: bash
 


### PR DESCRIPTION
The first scheduled `mswin-snapshot` run failed compiling `array.c` with `error C2065: 'n': undeclared identifier`. The runner's git checks out with `core.autocrlf=true`, and the prism-based rbinc generation in ruby/ruby (`tool/dump_ast.c` plus `tool/mk_builtin_loader.rb`) fails to associate `Primitive.cexpr!` with its enclosing method on CRLF sources, so the generated inline functions lose their locals. ruby/ruby's own Windows CI sets `core.autocrlf=false` and `core.eol=lf` before checkout and never sees this.

Cloning the snapshot source the same way fixes the daily build. Release builds are unaffected because tarballs already carry LF sources and pregenerated rbinc files. Reproduced and verified locally at ruby/ruby commit `9e195b7a51`. With a CRLF checkout both baseruby 3.2 and 4.1.0dev generate the broken `builtin_inline_class_*` functions, and after an LF re-checkout the same command generates the correct locals plumbing. Making the generator itself CRLF-safe is being pursued in ruby/ruby separately.

https://github.com/ruby/actions/actions/runs/29166004987

Generated with [Claude Code](https://claude.com/claude-code)
