### PR TITLE
Re-bootstrap vcpkg after updating its registry

### DIFF
--- a/.github/workflows/mswin-build.yml
+++ b/.github/workflows/mswin-build.yml
@@ -123,8 +123,12 @@ jobs:
           key: windows-2022-mswin-vcpkg-${{ hashFiles('src/vcpkg.json') }}
 
       - name: Install libraries with vcpkg
+        # The registry pinned by `builtin-baseline` can need a newer tool
+        # than the vcpkg.exe shipped in the runner image, so re-bootstrap
+        # it to the version the pulled registry asks for.
         run: |
           git -C "%VCPKG_INSTALLATION_ROOT%" pull --quiet
+          call "%VCPKG_INSTALLATION_ROOT%\bootstrap-vcpkg.bat"
           vcpkg install
         working-directory: src
         shell: cmd


### PR DESCRIPTION
The scheduled `mswin-snapshot` run fails at `vcpkg install` (https://github.com/ruby/actions/actions/runs/30946037613). microsoft/vcpkg bumped `scripts/vcpkg-tools.json` to schema version 2, which the `vcpkg.exe` bundled in the runner image cannot parse after the registry is updated by `git pull`. Call `bootstrap-vcpkg.bat` after the pull so the tool matches the pulled registry. Same fix as ruby/ruby commit f275e95ff2.
