### PR TITLE
Generate sitemap.xml for the Doxygen documentation

### DIFF
--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -29,6 +29,8 @@ jobs:
       - run: ./autogen.sh
       - run: ./configure
       - run: make Doxyfile
+      # SITEMAP_URL generates sitemap.xml under the HTML output (needs doxygen >= 1.9.7)
+      - run: echo 'SITEMAP_URL = https://docs.ruby-lang.org/capi/en/master/' >> Doxyfile
       - run: doxygen
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:


### PR DESCRIPTION
## Summary

Set `SITEMAP_URL` in the generated Doxyfile so that doxygen writes `sitemap.xml`
into `doc/capi/html`. The file is then uploaded to S3 together with the rest of
the pages by the existing `aws s3 sync` step and served at
https://docs.ruby-lang.org/capi/en/master/sitemap.xml (nginx on
docs.ruby-lang.org proxies `/capi/en/master/` to the `rubyci` bucket).

## Notes

- `SITEMAP_URL` is supported since doxygen 1.9.7. ubuntu-latest (24.04) installs
  1.9.8 via apt, so the runner is fine. When the tag is unset doxygen generates
  no sitemap, so other consumers of the Doxyfile are unaffected.
- The trailing slash in the value is required: doxygen builds each `<loc>` as
  `SITEMAP_URL` + filename by plain concatenation (verified in 1.9.8
  `src/sitemap.cpp`).
- Follow-up (separate PR to ruby/docs.ruby-lang.org): add
  `Sitemap: https://docs.ruby-lang.org/capi/en/master/sitemap.xml` to
  https://docs.ruby-lang.org/robots.txt once this has been deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
