### PR TITLE
Add rexml to update_binaries_index gemfile

### DIFF
--- a/tool/update_binaries_index.rb
+++ b/tool/update_binaries_index.rb
@@ -48,6 +48,10 @@ require "bundler/inline"
 gemfile do
   source "https://rubygems.org"
   gem "aws-sdk-s3"
+  # aws-sdk-core probes for an XML library at runtime instead of
+  # depending on one, and bundler hides the bundled rexml gem unless it
+  # is listed here.
+  gem "rexml"
 end
 
 require 'aws-sdk-s3'


### PR DESCRIPTION
The upload job in mswin-snapshot failed with `Unable to find a compatible xml library` raised by `aws-sdk-core` (https://github.com/ruby/actions/actions/runs/32061466816). `aws-sdk-core` now probes for an XML library at runtime instead of depending on one, and `bundler/inline` hides the bundled `rexml` gem unless it is listed in the gemfile. `tool/update_index.rb` and `tool/update_ci_versions.rb` already list `rexml`, so this adds the same entry to `tool/update_binaries_index.rb`.
