### PR TITLE
Wait long enough for the SignPath UI approval

### DIFF
--- a/.github/actions/sign-package/action.yml
+++ b/.github/actions/sign-package/action.yml
@@ -49,6 +49,14 @@ inputs:
       which is a rehearsal check, not a release gate.
     required: false
     default: 'true'
+  wait-timeout-seconds:
+    description: >-
+      How long to wait for the signing request to complete. Requests
+      signed with the SignPath Foundation production certificate need a
+      manual approval in the SignPath UI, so this covers the time until
+      an approver gets to it, not just the signing itself.
+    required: false
+    default: '3600'
 
 runs:
   using: composite
@@ -71,6 +79,7 @@ runs:
         artifact-configuration-slug: ${{ inputs.artifact-configuration-slug }}
         github-artifact-id: ${{ steps.unsigned.outputs.artifact-id }}
         wait-for-completion: true
+        wait-for-completion-timeout-in-seconds: ${{ inputs.wait-timeout-seconds }}
         output-artifact-directory: signed-artifact
 
     - name: Replace zip with the signed one

--- a/SIGNING.md
+++ b/SIGNING.md
@@ -2,7 +2,7 @@
 
 Free code signing provided by [SignPath.io](https://signpath.io), certificate by [SignPath Foundation](https://signpath.org).
 
-The Windows binary packages (`ruby-<version>-x64-mswin64_140.zip`) published under `https://cache.ruby-lang.org/pub/ruby/binaries/mswin64/` are built on GitHub Actions in this repository and signed through SignPath when the release is published. Signing requests run under the `signing` deployment environment, which is configured with manual approval. Every signature carries an RFC 3161 timestamp. `index.json` in `pub/ruby/binaries/` records for each build whether it is signed.
+The Windows binary packages (`ruby-<version>-x64-mswin64_140.zip`) published under `https://cache.ruby-lang.org/pub/ruby/binaries/mswin64/` are built on GitHub Actions in this repository and signed through SignPath when the release is published. Two manual approvals gate every production signature: the `signing` deployment environment in this repository, and the signing request itself in the SignPath UI, where SignPath Foundation requires per-request approval for production certificates. The workflow waits up to an hour for the latter, so approve the SignPath request promptly after approving the environment. Every signature carries an RFC 3161 timestamp. `index.json` in `pub/ruby/binaries/` records for each build whether it is signed.
 
 ## What is signed
 


### PR DESCRIPTION
Production certificate requests under the SignPath Foundation program require a per-request manual approval in the SignPath UI, unlike the auto-approved test certificate we rehearsed with in #137. The submit action's default 10 minute polling timeout would give up before an approver gets there. The workflow run then fails while the signing request stays pending on the SignPath side, and a re-run would submit a duplicate request.

`sign-package` now waits up to an hour by default, configurable via a new `wait-timeout-seconds` input, and `SIGNING.md` documents that a production signature passes two gates, the `signing` environment approval in this repository and the signing request approval in SignPath.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
